### PR TITLE
Fix greeter.py example

### DIFF
--- a/python/greeter/greeter.py
+++ b/python/greeter/greeter.py
@@ -5,7 +5,7 @@ def main(page):
 
     def btn_click(e):
         name = txt_name.value
-        page.clean(True)
+        page.clean()
         page.add(Text(f"Hello, {name}!"))
 
     txt_name = Textbox("Your name")


### PR DESCRIPTION
The greeter.py example isn't working. It gives the following error when its run:

`line 8, in btn_click page.clean(True)TypeError: clean() takes 1 positional argument but 2 were given`

It looks like the "True" argument isn't needed. The example works when the argument is removed.